### PR TITLE
release: prepare v1.1.0 – merge dev into main

### DIFF
--- a/app/src/main/java/com/zac15987/lockview/MainActivity.kt
+++ b/app/src/main/java/com/zac15987/lockview/MainActivity.kt
@@ -9,6 +9,9 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.zac15987.lockview.data.language.LanguageRepository
@@ -47,6 +50,7 @@ class MainActivity : ComponentActivity() {
                     // Device was unlocked by user
                     context?.let {
                         viewModel?.unlock(it.getString(R.string.image_unlocked_message))
+                        showSystemBars()
                     }
                 }
                 Intent.ACTION_SCREEN_OFF -> {
@@ -56,8 +60,22 @@ class MainActivity : ComponentActivity() {
         }
     }
     
+    fun hideSystemBars() {
+        val windowInsetsController = WindowCompat.getInsetsController(window, window.decorView)
+        windowInsetsController.apply {
+            hide(WindowInsetsCompat.Type.systemBars())
+            systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        }
+    }
+    
+    fun showSystemBars() {
+        val windowInsetsController = WindowCompat.getInsetsController(window, window.decorView)
+        windowInsetsController.show(WindowInsetsCompat.Type.systemBars())
+    }
+    
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         enableEdgeToEdge()
         
         // Register broadcast receiver for screen unlock events
@@ -97,6 +115,7 @@ class MainActivity : ComponentActivity() {
         if (wasDeviceLocked && !keyguardManager.isKeyguardLocked) {
             // Device was locked but now is unlocked - unlock the image too
             viewModel?.unlock(getString(R.string.image_unlocked_message))
+            showSystemBars()
             wasDeviceLocked = false
         }
     }

--- a/app/src/main/java/com/zac15987/lockview/data/ImageViewerState.kt
+++ b/app/src/main/java/com/zac15987/lockview/data/ImageViewerState.kt
@@ -45,6 +45,7 @@ class ImageViewerState(
     // Existing app-specific properties
     var imageUri: Uri? by mutableStateOf(null)
     var isLocked: Boolean by mutableStateOf(false)
+    var areSystemBarsHidden: Boolean by mutableStateOf(false)
     var isLoading: Boolean by mutableStateOf(false)
     var error: String? by mutableStateOf(null)
     var toastMessage: String? by mutableStateOf(null)

--- a/app/src/main/java/com/zac15987/lockview/ui/screens/ImageViewerScreen.kt
+++ b/app/src/main/java/com/zac15987/lockview/ui/screens/ImageViewerScreen.kt
@@ -1,7 +1,10 @@
 package com.zac15987.lockview.ui.screens
 
+import android.content.Context
+import android.content.ContextWrapper
 import android.content.Intent
 import android.net.Uri
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
@@ -31,10 +34,20 @@ import com.zac15987.lockview.data.theme.ThemePreference
 import com.zac15987.lockview.ui.components.AboutDialog
 import com.zac15987.lockview.ui.components.ImageViewer
 import com.zac15987.lockview.ui.components.LicensesDialog
+import com.zac15987.lockview.MainActivity
 import com.zac15987.lockview.utils.ImagePermissionHandler
 import com.zac15987.lockview.utils.hasImagePermission
 import com.zac15987.lockview.viewmodel.ImageViewerViewModel
 import com.zac15987.lockview.viewmodel.SettingsViewModel
+
+private fun Context.findActivity(): ComponentActivity? {
+    var context = this
+    while (context is ContextWrapper) {
+        if (context is ComponentActivity) return context
+        context = context.baseContext
+    }
+    return null
+}
 
 @Composable
 fun ImageViewerScreen(
@@ -50,6 +63,18 @@ fun ImageViewerScreen(
     var showThemeDialog by remember { mutableStateOf(false) }
     var showLanguageDialog by remember { mutableStateOf(false) }
     var showDonationDialog by remember { mutableStateOf(false) }
+    
+    // Handle system bars visibility based on lock state
+    LaunchedEffect(state.areSystemBarsHidden) {
+        val activity = context.findActivity() as? MainActivity
+        activity?.let {
+            if (state.areSystemBarsHidden) {
+                it.hideSystemBars()
+            } else {
+                it.showSystemBars()
+            }
+        }
+    }
     
     val failedToLoadImageText = stringResource(R.string.failed_to_load_image)
     val imageLockedMessage = stringResource(R.string.image_locked_message)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.11.1"
+agp = "8.12.0"
 kotlin = "2.0.21"
 coreKtx = "1.16.0"
 junit = "4.13.2"


### PR DESCRIPTION
This pull request merges the latest changes from `dev` into `main` in preparation for the **v1.1.0 release**.

---

### 🚀 v1.1.0 Highlights

#### ✨ Feature: Auto-Hide System Bars on Lock
- Automatically hides the **status bar** and **navigation bar** when locking the app.
- Bars are restored when the device is unlocked.
- Creates an immersive and distraction-free lock experience.

#### 🔧 Technical Improvements
- Adopted `WindowCompat.getInsetsController` for modern system UI control.
- Used **immersive sticky mode** for persistent full-screen behavior.
- Replaced `DisposableEffect` with `LaunchedEffect` for proper Compose reactivity.
- Updated `StateFlow` usage with `update {}` to ensure accurate state emissions.
- Compatible with Android API levels **24–36**.

#### 🛠 Build Tooling
- **Android Gradle Plugin** upgraded from `8.11.1` to `8.12.0` via `libs.versions.toml`.

---

### 🧪 QA & Testing
- Manually verified on:
  - Samsung Z Flip 5 (Android 15)
- Tested in both gesture and button navigation modes.
- Ensured correct lock/unlock behavior and bar transitions.

---

### 📁 Affected Files
- `MainActivity.kt`
- `ImageViewerViewModel.kt`
- `ImageViewerScreen.kt`
- `ImageViewerState.kt`
- `libs.versions.toml`

---

After this PR is merged into `main`, please create an version tag v1.1.0